### PR TITLE
Show video streams in separate window

### DIFF
--- a/Controls/VideoForm.Designer.cs
+++ b/Controls/VideoForm.Designer.cs
@@ -1,0 +1,47 @@
+namespace MissionPlanner.Controls
+{
+    partial class VideoForm
+    {
+        private System.ComponentModel.IContainer components = null;
+        private System.Windows.Forms.PictureBox pictureBox1;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // pictureBox1
+            // 
+            this.pictureBox1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.pictureBox1.Location = new System.Drawing.Point(0, 0);
+            this.pictureBox1.Name = "pictureBox1";
+            this.pictureBox1.Size = new System.Drawing.Size(640, 480);
+            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            this.pictureBox1.TabIndex = 0;
+            this.pictureBox1.TabStop = false;
+            // 
+            // VideoForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(640, 480);
+            this.Controls.Add(this.pictureBox1);
+            this.Name = "VideoForm";
+            this.Text = "Video";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.VideoForm_FormClosing);
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+            this.ResumeLayout(false);
+
+        }
+    }
+}

--- a/Controls/VideoForm.cs
+++ b/Controls/VideoForm.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Windows.Forms;
+using SkiaSharp;
+
+namespace MissionPlanner.Controls
+{
+    public partial class VideoForm : Form
+    {
+        public VideoForm()
+        {
+            InitializeComponent();
+        }
+
+        public void UpdateFrame(Bitmap frame)
+        {
+            if (IsDisposed)
+                return;
+
+            if (InvokeRequired)
+            {
+                BeginInvoke(new Action<Bitmap>(UpdateFrame), frame);
+                return;
+            }
+
+            var old = pictureBox1.Image;
+            if (frame == null)
+            {
+                pictureBox1.Image = null;
+            }
+            else
+            {
+                pictureBox1.Image = new Bitmap(frame.Width, frame.Height, 4 * frame.Width,
+                    System.Drawing.Imaging.PixelFormat.Format32bppPArgb,
+                    frame.LockBits(Rectangle.Empty, null, SKColorType.Bgra8888).Scan0);
+            }
+            old?.Dispose();
+        }
+
+        private void VideoForm_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            e.Cancel = true;
+            Hide();
+        }
+    }
+}

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -1840,7 +1840,7 @@ namespace MissionPlanner.GCSViews
 
         void cam_camimage(Image camimage)
         {
-            hud1.bgimage = camimage;
+            MainV2.UpdateVideoFrame(camimage as Bitmap);
         }
 
         private void CB_tuning_CheckedChanged(object sender, EventArgs e)
@@ -3089,6 +3089,7 @@ namespace MissionPlanner.GCSViews
         private void GStreamerStopToolStripMenuItem_Click(object sender, EventArgs e)
         {
             hudGStreamer.Stop();
+            MainV2.HideVideoWindow();
         }
 
         private void HereLinkVideoToolStripMenuItem_Click(object sender, EventArgs e)
@@ -3119,6 +3120,7 @@ namespace MissionPlanner.GCSViews
             }
 
             GCSViews.FlightData.hudGStreamer.Start(url);
+            MainV2.ShowVideoWindow();
         }
 
         private void hud_UserItem(object sender, EventArgs e)
@@ -4776,6 +4778,7 @@ namespace MissionPlanner.GCSViews
                 try
                 {
                     hudGStreamer.Start(url);
+                    MainV2.ShowVideoWindow();
                 }
                 catch (Exception ex)
                 {
@@ -4785,6 +4788,7 @@ namespace MissionPlanner.GCSViews
             else
             {
                 hudGStreamer.Stop();
+                MainV2.HideVideoWindow();
             }
         }
 
@@ -4843,10 +4847,12 @@ namespace MissionPlanner.GCSViews
                 CaptureMJPEG.URL = url;
 
                 CaptureMJPEG.runAsync();
+                MainV2.ShowVideoWindow();
             }
             else
             {
                 CaptureMJPEG.Stop();
+                MainV2.HideVideoWindow();
             }
         }
 
@@ -5049,6 +5055,7 @@ namespace MissionPlanner.GCSViews
                     MainV2.cam.Start();
 
                     MainV2.cam.camimage += new CamImage(cam_camimage);
+                    MainV2.ShowVideoWindow();
                 }
                 catch (Exception ex)
                 {

--- a/MainV2.cs
+++ b/MainV2.cs
@@ -557,6 +557,35 @@ namespace MissionPlanner
 
         public static bool isHerelink = false;
 
+        public static Controls.VideoForm videoForm;
+
+        public static void ShowVideoWindow()
+        {
+            if (videoForm == null || videoForm.IsDisposed)
+                videoForm = new Controls.VideoForm();
+
+            if (!videoForm.Visible)
+                videoForm.Show();
+        }
+
+        public static void HideVideoWindow()
+        {
+            if (videoForm != null)
+                videoForm.Hide();
+        }
+
+        public static void UpdateVideoFrame(Bitmap frame)
+        {
+            if (frame == null)
+            {
+                videoForm?.UpdateFrame(null);
+                return;
+            }
+
+            ShowVideoWindow();
+            videoForm.UpdateFrame(frame);
+        }
+
         public static MainSwitcher View;
 
         /// <summary>
@@ -3406,19 +3435,7 @@ namespace MissionPlanner
             {
                 try
                 {
-                    if (image == null)
-                    {
-                        GCSViews.FlightData.myhud.bgimage = null;
-                        return;
-                    }
-
-                    var old = GCSViews.FlightData.myhud.bgimage;
-                    GCSViews.FlightData.myhud.bgimage = new Bitmap(image.Width, image.Height, 4 * image.Width,
-                        PixelFormat.Format32bppPArgb,
-                        image.LockBits(Rectangle.Empty, null, SKColorType.Bgra8888)
-                            .Scan0);
-                    if (old != null)
-                        old.Dispose();
+                    MainV2.UpdateVideoFrame(image);
                 }
                 catch
                 {
@@ -3429,20 +3446,7 @@ namespace MissionPlanner
             {
                 try
                 {
-                    if (image == null)
-                    {
-                        GCSViews.FlightData.myhud.bgimage = null;
-                        return;
-                    }
-
-                    var old = GCSViews.FlightData.myhud.bgimage;
-                    GCSViews.FlightData.myhud.bgimage = new Bitmap(image.Width,
-                        image.Height,
-                        4 * image.Width,
-                        PixelFormat.Format32bppPArgb,
-                        image.LockBits(Rectangle.Empty, null, SKColorType.Bgra8888).Scan0);
-                    if (old != null)
-                        old.Dispose();
+                    MainV2.UpdateVideoFrame(image);
                 }
                 catch
                 {
@@ -3453,18 +3457,7 @@ namespace MissionPlanner
             {
                 try
                 {
-                    if (image == null)
-                    {
-                        GCSViews.FlightData.myhud.bgimage = null;
-                        return;
-                    }
-
-                    var old = GCSViews.FlightData.myhud.bgimage;
-                    GCSViews.FlightData.myhud.bgimage = new Bitmap(image.Width, image.Height, 4 * image.Width,
-                        PixelFormat.Format32bppPArgb,
-                        image.LockBits(Rectangle.Empty, null, SKColorType.Bgra8888).Scan0);
-                    if (old != null)
-                        old.Dispose();
+                    MainV2.UpdateVideoFrame(image);
                 }
                 catch
                 {


### PR DESCRIPTION
## Summary
- add new VideoForm to display external video streams
- hook up VideoForm management utilities in `MainV2`
- show the VideoForm whenever MJPEG, GStreamer or camera streams start
- stop showing the form when video streams stop
- route all video frames to the separate window instead of the HUD

## Testing
- `dotnet build MissionPlanner.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f8f495408320b71d5ceb1293542c